### PR TITLE
docs: Apply professional README (merge conflict resolution fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-# Vibe Docker Init
+# Vibe-to-Docker
 
 [![npm version](https://badge.fury.io/js/vibe-to-docker.svg)](https://www.npmjs.com/package/vibe-to-docker)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js Version](https://img.shields.io/badge/node-%3E%3D20.8.1-brightgreen.svg)](https://nodejs.org/)
-[![Build Status](https://img.shields.io/badge/build-passing-brightgreen.svg)](https://github.com/your-username/vibe-to-docker)
-[![Tests](https://img.shields.io/badge/tests-368%20passing-brightgreen.svg)](https://github.com/your-username/vibe-to-docker)
-[![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen.svg)](https://github.com/your-username/vibe-to-docker)
+[![Tests](https://img.shields.io/badge/tests-1%2C231%20passing-brightgreen.svg)](https://github.com/wrsmith108/vibe-to-docker)
+[![Coverage](https://img.shields.io/badge/coverage-99.4%25-brightgreen.svg)](https://github.com/wrsmith108/vibe-to-docker)
 
 Universal Docker containerization tool for AI-generated projects. Automatically detects and configures Docker for projects created with Lovable, Bolt, V0, and Figma Make.
 
@@ -18,28 +17,14 @@ Universal Docker containerization tool for AI-generated projects. Automatically 
 - **Per-Project Setup**: Configurations install to `.vibe-docker/` directory
 - **Multi-Service Support**: Full-stack applications with databases and backends
 
-**Key Features:**
-- ✅ **Zero Warning Installation**: Clean output with no template or configuration warnings
-- ✅ **Per-Project Configuration**: Each project gets its own `.vibe-docker/` directory
-- ✅ **Detached Mode by Default**: Containers start in background, terminal returns immediately
-- ✅ **HTTP-Only Development**: Simplified nginx configuration without SSL complexity
-- ✅ **Automatic .env Creation**: No manual file copying required
-- ✅ **GitHub Codespaces Ready**: Validated and tested in cloud development environments
+## Quick Start
 
 ```bash
-npx vibe-to-docker basic
-```
-
-**Quick Start:**
-```bash
-# Navigate to your React/Vite project
+# Navigate to your AI-generated project
 cd your-project
 
-# Initialize Docker configuration
-npx vibe-to-docker basic
-
-# Start containers in background
-cd .vibe-docker && docker-compose up -d --build
+# Initialize Docker configuration (auto-detects project type)
+npx vibe-to-docker init
 
 # Start containers
 cd .vibe-docker && docker-compose up -d --build
@@ -52,42 +37,33 @@ Your application will be available at `http://localhost:3000`.
 ### One-Time Use (Recommended)
 
 ```bash
-npx vibe-to-docker@beta basic
+npx vibe-to-docker init
 ```
 
 ### Global Installation
 
 ```bash
-npx vibe-to-docker@beta basic
+npm install -g vibe-to-docker
+vibe-to-docker init
 ```
 
 ### Local Development
 
 ```bash
-npx vibe-to-docker@beta basic
+npm install --save-dev vibe-to-docker
 ```
 
 ## Supported Tools
 
 ### Lovable (React + Vite + Supabase)
 
----
-
-### v2.0.0-beta.5 - Documentation Fix (October 26, 2025)
-📝 **DOCUMENTATION**: Fixed docker-compose instructions
-
-**Fixed Issues:**
-- ✅ **Clearer Instructions**: Updated docker-compose command to include cd to .vibe-docker directory
-- ✅ **User Confusion**: Removed "no configuration file provided" error by clarifying directory navigation
-
-**Installation:**
 ```bash
-npx vibe-to-docker@beta basic
-```
+cd my-lovable-project
+npx vibe-to-docker init --tool=lovable
 
-**What Changed:**
-- Updated "Next Steps" to show: `cd .vibe-docker && docker-compose up --build`
-- Clarified that Docker files are in the `.vibe-docker/` subdirectory
+# Configure Supabase credentials in .vibe-docker/.env
+# VITE_SUPABASE_URL=https://xxx.supabase.co
+# VITE_SUPABASE_ANON_KEY=your-key
 
 cd .vibe-docker && docker-compose up -d --build
 ```
@@ -97,8 +73,8 @@ cd .vibe-docker && docker-compose up -d --build
 ### Bolt (Remix + TypeScript)
 
 ```bash
-npx vibe-to-docker@beta basic
-```
+cd my-bolt-project
+npx vibe-to-docker init --tool=bolt
 
 cd .vibe-docker && docker-compose up -d --build
 ```
@@ -108,64 +84,35 @@ cd .vibe-docker && docker-compose up -d --build
 ### V0 (Next.js 14 + shadcn/ui)
 
 ```bash
-npx vibe-to-docker@beta basic
-```
-
-**What Changed:**
-- The setup script now automatically creates `.env` from `.env.example`
-- Simplified docker-compose.yml template focuses on essential services
-- Fixed build context paths to properly reference project files
-- Removed complex monitoring services for cleaner initial setup
+cd my-v0-project
+npx vibe-to-docker init --tool=v0
 
 cd .vibe-docker && docker-compose up -d --build
 ```
 
 **Features**: Server-side rendering, API routes, static optimization
 
-**Fixed Issues:**
-- ✅ **Module System Compatibility**: Converted CommonJS modules to ES modules for proper import/export
-- ✅ **Missing Dependencies**: Added `ensureVibeDockerStructure` function that was causing runtime errors
-- ✅ **Template Path Resolution**: Fixed template discovery to correctly locate package templates
-- ✅ **GitHub Codespaces Support**: Now works correctly in all npx environments
+### Figma Make (React + Vite)
 
 ```bash
-npx vibe-to-docker@beta basic
+cd my-figma-project
+npx vibe-to-docker init --tool=figma-make
+
+cd .vibe-docker && docker-compose up -d --build
 ```
 
 **Features**: Design-to-code projects, TypeScript support
 
 ## Usage
 
-### v2.0.0 - Per-Project Installation Architecture (October 2025)
-- **Per-Project Installation**: Docker configurations now install to `.vibe-docker/` directory in each project
-- **Improved Path Resolution**: Enhanced path handling for multi-project workflows
-- **Better Organization**: Centralized configuration management per project
-- **Migration Support**: Seamless migration from global to per-project setup
-- **100% Test Coverage**: All 368 tests passing across Ubuntu, Windows, and macOS
-- **Enhanced Error Handling**: Better validation and user feedback
+### Commands
 
 ```bash
 # Initialize with auto-detection
 vibe-to-docker init
 
-### v3.0.0 - Universal Tool Support (Coming Soon)
-
-- **🎯 Automatic Tool Detection**: Intelligent detection of Figma Make, Lovable, V0, and Bolt projects
-- **🔧 Tool-Specific Optimizations**: Tailored Docker configurations for each AI development tool
-- **⚡ Enhanced CLI**: New `--tool` flag for explicit tool selection
-- **📚 Comprehensive Guides**: Detailed documentation for each supported tool
-- **🔄 Multi-Service Support**: Docker Compose orchestration for fullstack applications
-- **🗄️ Database Integration**: Automatic Supabase, PostgreSQL, MySQL configuration
-
-### Core Features
-
-- **Per-Project Configuration**: Each project gets its own `.vibe-docker/` directory
-- **Multiple Templates**: Choose from optimized configurations for different project types
-- **Production Ready**: Includes Nginx configuration, multi-stage builds, and security best practices
-- **Zero Config**: Works out of the box with sensible defaults
-- **Customizable**: Easy to modify generated files for specific needs
-- **TypeScript Support**: Full TypeScript support with optimized builds
-- **Development Friendly**: Hot reload support and development configurations
+# Specify tool explicitly
+vibe-to-docker init --tool=<lovable|bolt|v0|figma-make>
 
 # Preview without writing files
 vibe-to-docker init --dry-run
@@ -173,29 +120,30 @@ vibe-to-docker init --dry-run
 # Overwrite existing configuration
 vibe-to-docker init --force
 
-```bash
-npm install -g vibe-to-docker
-```
+# Show help
+vibe-to-docker --help
 
 # Show version
 vibe-to-docker --version
 
-```bash
-npx vibe-to-docker [template]
+# List available templates
+vibe-to-docker --list
 ```
 
 ### Legacy Templates (v2.x Compatible)
 
 ```bash
-npm install --save-dev vibe-to-docker
+# Basic setup (simple frontend projects)
+vibe-to-docker basic
+
+# UI-heavy setup (large component libraries)
+vibe-to-docker ui-heavy
 ```
 
 ## Generated Files
 
 Running `vibe-to-docker init` creates a `.vibe-docker/` directory in your project:
 
-```bash
-vibe-to-docker ui-heavy
 ```
 your-project/
 ├── .vibe-docker/
@@ -209,137 +157,37 @@ your-project/
 └── [your project files]
 ```
 
-## 🛠️ Usage
+### File Descriptions
 
-### Quick Start (v3.0.0 Preview)
-
-```bash
-# Auto-detect project type and initialize
-vibe-to-docker init
-
-# Or specify tool explicitly
-vibe-to-docker init --tool=lovable
-vibe-to-docker init --tool=figma-make
-vibe-to-docker init --tool=v0
-vibe-to-docker init --tool=bolt
-```
-
-### Basic Command (v2.x Compatible)
-
-```bash
-vibe-to-docker [template] [options]
-```
+- **Dockerfile**: Optimized multi-stage build with development and production targets
+- **docker-compose.yml**: Service definitions, networks, and volumes
+- **nginx.conf**: Production-ready nginx with security headers and caching
+- **.env**: Auto-generated from template, customize as needed
+- **DOCKER.md**: Comprehensive Docker usage guide
 
 ## Docker Commands
 
-#### `basic`
-Minimal Docker setup for simple frontend projects:
-- Basic Dockerfile with Node.js
-- Simple docker-compose.yml
-- Basic Nginx configuration
-- Environment file template
-
-**Best For:** Figma Make, simple React/Vue/Svelte apps
+### Development
 
 ```bash
-vibe-to-docker basic
-```
+# Start containers in background
+docker-compose up -d --build
 
-#### `ui-heavy`
-Optimized for UI-heavy applications with advanced caching:
-- Multi-stage Dockerfile with build optimization
-- Advanced Nginx configuration with gzip and caching
-- Performance-optimized docker-compose setup
-- Comprehensive environment configuration
+# View logs
+docker-compose logs -f
 
-**Best For:** Large component libraries, design systems
-
-```bash
-vibe-to-docker ui-heavy
-```
-
-#### `fullstack` (v3.0.0)
-Complete setup for fullstack applications:
-- Multi-service docker-compose
-- Frontend + Backend containers
-- Database service (PostgreSQL/MySQL)
-- Nginx reverse proxy
-
-**Best For:** Lovable, Bolt fullstack projects
-
-```bash
-vibe-to-docker init --template=fullstack
-```
-
-#### `nextjs` (v3.0.0)
-Optimized for Next.js applications:
-- Next.js standalone build
-- Server-side rendering support
-- API routes configuration
-- Static + dynamic optimization
-
-**Best For:** V0, Next.js projects
-
-```bash
-vibe-to-docker init --template=nextjs
-```
-
-#### `supabase` (v3.0.0)
-Configured for Supabase integration:
-- Supabase client setup
-- Environment variable templates
-- Authentication configuration
-- Real-time features support
-
-**Best For:** Lovable projects with Supabase
-
-```bash
-vibe-to-docker init --template=supabase
+# Stop containers
+docker-compose down
 ```
 
 ### Production
 
 ```bash
-# Show help information
-vibe-to-docker --help
-vibe-to-docker -h
+# Build production image
+docker build --target production -t myapp:latest .
 
-# Show version
-vibe-to-docker --version
-vibe-to-docker -v
-
-# List all available templates
-vibe-to-docker --list
-
-# Initialize with auto-detection (v3.0.0)
-vibe-to-docker init
-
-# Specify tool explicitly (v3.0.0)
-vibe-to-docker init --tool=<tool>
-
-# Preview without writing files (v3.0.0)
-vibe-to-docker init --dry-run
-
-# Overwrite existing configuration (v3.0.0)
-vibe-to-docker init --force
-```
-
-## 📁 Generated Files
-
-The CLI generates the following files in your project's `.vibe-docker/` directory:
-
-```
-your-project/
-├── .vibe-docker/          # Per-project Docker configuration
-│   ├── config.json         # Project-specific settings
-│   ├── Dockerfile          # Multi-stage build configuration
-│   ├── docker-compose.yml  # Container orchestration
-│   ├── .dockerignore       # Files to exclude from build context
-│   ├── nginx.conf          # Nginx server configuration
-│   ├── .env.example        # Environment variables template
-│   └── DOCKER.md           # Detailed documentation
-├── package.json            # Updated with Docker scripts
-└── [your project files]
+# Run production container
+docker run -p 80:80 --env-file .env myapp:latest
 ```
 
 ### Maintenance
@@ -461,173 +309,8 @@ jobs:
 
 ### User Guides
 
-- Node.js >= 20.8.1
-- npm >= 10.0.0
-- Docker >= 20.0.0
-- Docker Compose >= 2.0.0
-
-### Contributing
-
-1. Fork the repository
-2. Create a feature branch: `git checkout -b feature-name`
-3. Make your changes and test thoroughly
-4. Commit with conventional commits: `git commit -m "feat: add new template"`
-5. Push and create a Pull Request
-
-### Adding New Templates
-
-1. Create a new directory in `templates/`
-2. Add template files (Dockerfile, docker-compose.yml, etc.)
-3. Update the CLI to recognize the new template
-4. Add documentation and examples
-
-## 📚 Examples
-
-### Figma Make Project
-
-```bash
-cd my-figma-project
-vibe-to-docker init --tool=figma-make
-cd .vibe-docker && docker-compose up -d --build
-# App available at http://localhost:3000
-```
-
-### Lovable Fullstack Project
-
-```bash
-cd my-lovable-app
-vibe-to-docker init --tool=lovable
-
-# Configure Supabase credentials
-nano .vibe-docker/.env
-# Add VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY
-
-cd .vibe-docker && docker-compose up -d --build
-# App available at http://localhost:3000
-```
-
-### V0 Next.js Project
-
-```bash
-cd my-v0-project
-vibe-to-docker init --tool=v0
-
-cd .vibe-docker && docker-compose up -d --build
-# App available at http://localhost:3000
-```
-
-### Bolt Multi-Service Project
-
-```bash
-cd my-bolt-app
-vibe-to-docker init --tool=bolt
-
-# Review generated multi-service configuration
-cat .vibe-docker/docker-compose.yml
-
-cd .vibe-docker && docker-compose up -d --build
-# Frontend: http://localhost:3000
-# Backend API: http://localhost:3001
-```
-
-### Complex UI Application
-
-```bash
-# For apps with heavy UI components
-vibe-to-docker ui-heavy
-cd .vibe-docker
-cp .env.example .env
-# Edit .env with your configuration
-docker-compose up -d --build
-```
-
-- **[Lovable Guide](docs/guides/LOVABLE_GUIDE.md)** - Fullstack apps with Supabase
-- **[Figma Make Guide](docs/guides/FIGMA_MAKE_GUIDE.md)** - Design-to-code projects
-- **[V0 Guide](docs/guides/V0_GUIDE.md)** - Next.js and Tailwind projects
-- **[Bolt Guide](docs/guides/BOLT_GUIDE.md)** - WebContainer fullstack apps
-
-```bash
-# Build production image
-cd .vibe-docker
-docker build --target production -t myapp:v1.0.0 .
-
-- **[API Reference](docs/API.md)** - Programmatic usage
-- **[Template Architecture](docs/TEMPLATE_ARCHITECTURE.md)** - System design
-- **[Contributing Guide](CONTRIBUTING.md)** - Development guide
-
-## Requirements
-
-### Common Issues
-
-**Build fails with permission errors:**
-```bash
-# Fix permissions
-sudo chown -R $USER:$USER .
-```
-
-**Port already in use:**
-```bash
-# Change port in docker-compose.yml or .env
-ports:
-  - "8080:80"  # Use different host port
-
-# Or update .env
-DEV_PORT=5000
-NGINX_PORT=7000
-```
-
-**Out of disk space:**
-```bash
-# Clean up Docker
-docker system prune -a
-```
-
-**Module not found errors:**
-```bash
-# Rebuild without cache
-docker-compose build --no-cache
-```
-
-**Supabase connection fails (Lovable projects):**
-```bash
-# Verify credentials in .vibe-docker/.env
-VITE_SUPABASE_URL=https://xxx.supabase.co
-VITE_SUPABASE_ANON_KEY=your-key
-
-# Rebuild container
-cd .vibe-docker
-docker-compose up -d --build
-```
-
-**Environment variables not available:**
-```bash
-# Ensure variables are prefixed correctly:
-# - VITE_* for Vite projects
-# - NEXT_PUBLIC_* for Next.js projects
-# - No prefix for server-side only
-
-# Rebuild after changing .env
-docker-compose up -d --build
-```
-
-### Tool-Specific Troubleshooting
-
-For detailed troubleshooting, see the tool-specific guides:
-- [Lovable Troubleshooting](docs/guides/LOVABLE_GUIDE.md#troubleshooting)
-- [Figma Make Troubleshooting](docs/guides/FIGMA_MAKE_GUIDE.md#troubleshooting)
-- [V0 Troubleshooting](docs/guides/V0_GUIDE.md#troubleshooting)
-- [Bolt Troubleshooting](docs/guides/BOLT_GUIDE.md#troubleshooting)
-
-## 📄 License
-
-MIT License - see [LICENSE](LICENSE) file for details.
-
-## 📖 Documentation
-
-### User Guides
-
-- **[CLI User Guide](docs/CLI_USER_GUIDE.md)** - Complete CLI reference and usage
-- **[Migration Guide v2→v3](docs/MIGRATION_V2_TO_V3.md)** - Upgrade from v2.x to v3.0
+- **[CLI User Guide](docs/CLI_USER_GUIDE.md)** - Complete CLI reference
+- **[Migration Guide v2→v3](docs/MIGRATION_V2_TO_V3.md)** - Upgrade guide
 
 ### Tool-Specific Guides
 
@@ -639,10 +322,21 @@ MIT License - see [LICENSE](LICENSE) file for details.
 ### Technical Documentation
 
 - **[API Reference](docs/API.md)** - Programmatic usage
-- **[Architecture](docs/TEMPLATE_ARCHITECTURE.md)** - Template system design
-- **[Contributing](CONTRIBUTING.md)** - Development guide
+- **[Template Architecture](docs/TEMPLATE_ARCHITECTURE.md)** - System design
+- **[Contributing Guide](CONTRIBUTING.md)** - Development guide
 
-## 🤝 Support
+## Requirements
+
+- Node.js >= 20.8.1
+- npm >= 10.0.0
+- Docker >= 20.0.0
+- Docker Compose >= 2.0.0
+
+## License
+
+MIT License - see [LICENSE](LICENSE) file for details.
+
+## Support
 
 - 📖 [Documentation](https://github.com/wrsmith108/vibe-to-docker#readme)
 - 🐛 [Issue Tracker](https://github.com/wrsmith108/vibe-to-docker/issues)
@@ -650,13 +344,8 @@ MIT License - see [LICENSE](LICENSE) file for details.
 
 ## Acknowledgments
 
-- Inspired by create-react-app and similar bootstrapping tools
-- Built for the AI-powered development community
-- Optimized for Figma Make, Lovable, V0, Bolt, and modern frameworks
-- Special thanks to all contributors and early adopters
+Built for the AI-powered development community. Supporting Figma Make, Lovable, V0, Bolt, and modern web frameworks.
 
 ---
 
 **Made with ❤️ for the AI-powered development community**
-
-Supporting: Figma Make • Lovable • V0 • Bolt • And more...


### PR DESCRIPTION
The PR merge incorrectly used the old README (662 lines with beta history). This commit applies the professional README from 3f4785f:
- 351 lines (53% reduction from 750 lines)
- Updated badges: 1,231 tests, 99.4% coverage
- Removed beta testing history
- Professional, concise documentation