### PR TITLE
fix(release): Correct repository URLs for semantic-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,12 +44,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/wrsmith108/vibe-to-docker.git"
+    "url": "https://github.com/wrsmith108/figma-docker-init.git"
   },
   "bugs": {
-    "url": "https://github.com/wrsmith108/vibe-to-docker/issues"
+    "url": "https://github.com/wrsmith108/figma-docker-init/issues"
   },
-  "homepage": "https://github.com/wrsmith108/vibe-to-docker",
+  "homepage": "https://github.com/wrsmith108/figma-docker-init",
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/wrsmith108"


### PR DESCRIPTION
CRITICAL FIX: semantic-release was failing because package.json contained wrong repository URLs (vibe-to-docker instead of figma-docker-init).

Changed:
- repository.url: https://github.com/wrsmith108/vibe-to-docker.git → https://github.com/wrsmith108/figma-docker-init.git
- bugs.url: figma-docker-init
- homepage: figma-docker-init

This fix unblocks npm publication via semantic-release.