### PR TITLE
fix(cache): prevent race condition causing null cache results

### DIFF
--- a/src/core/cache.js
+++ b/src/core/cache.js
@@ -26,8 +26,13 @@ export class DetectionCache {
 
   async set(detectionResult) {
     await fs.mkdir(this.cacheDir, { recursive: true });
+
+    // Get package.json mtime and ensure cache timestamp is after it
+    const pkgStat = await fs.stat(path.join(this.projectRoot, 'package.json'));
+    const timestamp = Math.max(Date.now(), pkgStat.mtimeMs + 1);
+
     await fs.writeFile(this.cacheFile, JSON.stringify({
-      timestamp: Date.now(),
+      timestamp,
       result: detectionResult
     }, null, 2));
   }


### PR DESCRIPTION
Ensure cache timestamp is always greater than package.json mtime to prevent immediate cache invalidation. Fixes 5 failing tests in tests/core/cache.test.js.

The issue occurred when Date.now() returned a value <= package.json mtime, causing cache.get() to return null immediately after cache.set().

Resolution: Set cache timestamp to max(Date.now(), pkgMtime + 1)